### PR TITLE
Move copy log button to left

### DIFF
--- a/assets/components/controlerrorlog/js/mgr/cel.default.js
+++ b/assets/components/controlerrorlog/js/mgr/cel.default.js
@@ -7,7 +7,7 @@ function showLog() {
 			cloaseAction: 'hide',
 			title: _("error_log") ? _("error_log") : 'Error log',
 			stateful: false,
-			buttonAlign: "right",
+			buttonAlign: "left",
 			items: [{
 				xtype: "textarea",
 				name: "log",
@@ -55,6 +55,13 @@ function showLog() {
 				hidden: !(cel_config.tooLarge && cel_config.last > 0)
 			}],
 			buttons: [{
+                text: '<i class="icon icon-copy"></i> ' + (_("cel_copy") ? _("cel_copy") : 'Make a copy'),
+                id: "error-log-copy-btn",
+                handler: function () {
+                    celWindow._copy();
+                },
+                scope: this
+            }, '->', {
 				text: '<i class="icon icon-refresh"></i> ' + (_("cel_refresh") ? _("cel_refresh") : 'Refresh'),
 				id: "error-log-refresh-btn",
 				handler: function () {
@@ -92,13 +99,6 @@ function showLog() {
 							}
 						}
 					});
-				},
-				scope: this
-			}, {
-				text: '<i class="icon icon-copy"></i> ' + (_("cel_copy") ? _("cel_copy") : 'Make a copy'),
-				id: "error-log-copy-btn",
-				handler: function () {
-					celWindow._copy();
 				},
 				scope: this
 			}, {


### PR DESCRIPTION
Использую данный плагин на многих проектах. После обновления вместо очистки лога на автомате начал регулярно делать копии логов, так как привык к старому расположению кнопок. Копии потом приходится вычищать и тратить на это время. Предполагаю, что данная проблема не только у меня.

Есть предложение перенести новую кнопку налево, что с моей точки зрения более логично и сохранив старый порядок кнопок . Патч прилагаю :)