### PR TITLE
Add a usermenuUl exist check

### DIFF
--- a/assets/components/controlerrorlog/js/mgr/cel.default.js
+++ b/assets/components/controlerrorlog/js/mgr/cel.default.js
@@ -373,6 +373,6 @@ Ext.onReady(function() {
 	errorlogLi.innerHTML = "<a id=\"errorlog-link\" class=\""+controlErrorLog.getClass(controlErrorLog.config.empty)+"\" href=\"javascript:controlErrorLog.showLog()\" title=\""+ title +"\"><i" +
 		" class=\"celicon\"></i></a>";
 	errorlogLi.className = "errorlog-li";
-	usermenuUl.insertBefore(errorlogLi, usermenuUl.firstChild);
+	if (usermenuUl) { usermenuUl.insertBefore(errorlogLi, usermenuUl.firstChild); }
 	if (controlErrorLog.config.auto_refresh) setInterval(controlErrorLog.refreshLog, controlErrorLog.config.refresh_freq);
 });


### PR DESCRIPTION
If the MODX browser is opened, controlErrorLog throws an error:

```
cel.default.js:376 Uncaught TypeError: Cannot read property 'insertBefore' of null
```